### PR TITLE
Added scripts to run.py

### DIFF
--- a/crawler/run.py
+++ b/crawler/run.py
@@ -1,3 +1,7 @@
 import subprocess
-result = subprocess.Popen('scrapy crawl coinspot -o test_data.csv',
+result = subprocess.Popen('scrapy crawl coinspot -o ../data/test_data.csv',
                           stdout=subprocess.PIPE, shell=True).communicate()[0]
+data_process = subprocess.Popen('python ../processors/process_data.py',
+        stdout=subprocess.PIPE, shell=True).communicate()[0]
+csv_process = subprocess.Popen('python ../processors/process_csv.py',
+        stdout=subprocess.PIPE, shell=True).communicate()[0]


### PR DESCRIPTION
Added lines to the run.py file to trigger the process_data and process_csv scripts, resolves #16 

This is triggering an error on my end when it gets to the process_csv file: `TypeError: unsupported operand type(s) for -: 'str' and 'str'` on Line 4 of process_csv.py.

This error occurs when running the scripts manually in order, so I don't think it has to do with the way they're called from run.py. Seems to be that it's reading `indata['buy']` and `indata['sell']` as strings from the csv.

Since it happens when I call the scripts manually, I'm thinking it's more to do with something on my local environment. But worth noting.